### PR TITLE
Feature 316 Containerisation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+FROM python:3.10-slim
+WORKDIR /code
+
+ENV FLASK_CONFIG=application.config.DevelopmentConfig
+ENV FLASK_APP=application.wsgi:app
+
+ENV FLASK_RUN_HOST=0.0.0.0
+ENV FLASK_RUN_PORT=5050
+ENV FLASK_DEBUG=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc g++ git libproj-dev proj-bin gdal-bin wget gnupg2  \
+    && rm -rf /var/lib/apt/lists/*
+
+
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+
+RUN apt-get update && \
+    apt-get install -y postgresql-client-16 && \
+    rm -rf /var/lib/apt/lists/*
+COPY . .
+RUN pip install -r requirements/requirements.txt
+RUN pip install -r requirements/dev-requirements.txt
+EXPOSE 5050
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+flask db upgrade
+flask run --debug


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Added Dockerfile with entrypoint file for running app as container with AWS ECS

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link: https://github.com/digital-land/technical-documentation/issues/319#issue-2931872522
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: tested manually
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
